### PR TITLE
Fix year switch problems

### DIFF
--- a/src/passes/CompletedMatchPass.js
+++ b/src/passes/CompletedMatchPass.js
@@ -64,8 +64,17 @@ CompletedMatchPass.prototype = {
             return Q();
         }
 
+        var scheduled = moment.utc(matches[1], 'MMM DD HH:mm', 'en');
+        var current = moment.utc();
+
+        if (scheduled.diff(current, 'months') > 6) {
+            scheduled.subtract(1, 'years');
+        } else if (scheduled.diff(current, 'months') < -6) {
+            scheduled.add(1, 'years');
+        }
+
         // title is a valid format, check if the date is in the past
-        if (moment.utc(matches[1], 'MMM DD HH:mm', 'en').diff(moment.utc()) > 0) {
+        if (scheduled.diff(current) > 0) {
             return Q(); // game title still in the future
         }
 

--- a/src/passes/TitleFormatPass.js
+++ b/src/passes/TitleFormatPass.js
@@ -181,8 +181,17 @@ TitleFormatPass.prototype = {
 
         // check the title is in a valid format
         if (null !== matches) {
+            var scheduled = moment.utc(matches[1], 'MMM DD HH:mm', 'en');
+            var current = moment.utc();
+
+            if (scheduled.diff(current, 'months') > 6) {
+                scheduled.subtract(1, 'years');
+            } else if (scheduled.diff(current, 'months') < -6) {
+                scheduled.add(1, 'years');
+            }
+
             // title is a valid format, check if the date is in the past
-            if (moment.utc(matches[1], 'MMM DD HH:mm', 'en').diff(moment.utc()) < 0) {
+            if (scheduled.diff(moment.utc()) < 0) {
                 logger.info('Post ID %s title (%s) is in the past. Adding a comment to the post and removing it', post.data.name, post.data.title);
 
                 promises.push(this._leaveComment(this._timeResponse, post.data.name));

--- a/src/passes/TitleFormatPass.js
+++ b/src/passes/TitleFormatPass.js
@@ -191,7 +191,7 @@ TitleFormatPass.prototype = {
             }
 
             // title is a valid format, check if the date is in the past
-            if (scheduled.diff(moment.utc()) < 0) {
+            if (scheduled.diff(current) < 0) {
                 logger.info('Post ID %s title (%s) is in the past. Adding a comment to the post and removing it', post.data.name, post.data.title);
 
                 promises.push(this._leaveComment(this._timeResponse, post.data.name));


### PR DESCRIPTION
Assumes any posts with titles over 6 months ago are actually a year ahead and any with titles over 6 months in the future are a year behind. Keeps all post titles within 6 months of the current day and means there is no need to supply a year in the post title
